### PR TITLE
Refactor uptime access via DI

### DIFF
--- a/Core/ServerStatusUpdater.cs
+++ b/Core/ServerStatusUpdater.cs
@@ -2,6 +2,7 @@
 using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Rooms;
+using Plus;
 
 namespace Plus.Core;
 
@@ -12,13 +13,15 @@ public class ServerStatusUpdater : IDisposable, IServerStatusUpdater
     private readonly IDatabase _database;
     private readonly IGameClientManager _gameClientManager;
     private readonly IRoomManager _roomManager;
+    private readonly IPlusEnvironment _environment;
 
-    public ServerStatusUpdater(ILogger<ServerStatusUpdater> logger, IDatabase database, IGameClientManager gameClientManager, IRoomManager roomManager)
+    public ServerStatusUpdater(ILogger<ServerStatusUpdater> logger, IDatabase database, IGameClientManager gameClientManager, IRoomManager roomManager, IPlusEnvironment environment)
     {
         _logger = logger;
         _database = database;
         _gameClientManager = gameClientManager;
         _roomManager = roomManager;
+        _environment = environment;
     }
 
     private Timer _timer;
@@ -47,7 +50,7 @@ public class ServerStatusUpdater : IDisposable, IServerStatusUpdater
 
     private void UpdateOnlineUsers()
     {
-        var uptime = DateTime.Now - PlusEnvironment.ServerStarted;
+        var uptime = DateTime.Now - _environment.ServerStarted;
         var usersOnline = _gameClientManager.Count;
         var roomCount = _roomManager.Count;
         Console.Title = $"Plus Emulator - {usersOnline} users online - {roomCount} rooms loaded - {uptime.Days} day(s) {uptime.Hours} hour(s) uptime";

--- a/HabboHotel/Rooms/Chat/Commands/User/InfoCommand.cs
+++ b/HabboHotel/Rooms/Chat/Commands/User/InfoCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Plus.Communication.Packets.Outgoing.Rooms.Notifications;
 using Plus.HabboHotel.GameClients;
+using Plus;
 
 namespace Plus.HabboHotel.Rooms.Chat.Commands.User;
 
@@ -7,6 +8,7 @@ internal class InfoCommand : IChatCommand
 {
     private readonly IGameClientManager _gameClientManager;
     private readonly IRoomManager _roomManager;
+    private readonly IPlusEnvironment _environment;
     public string Key => "about";
     public string PermissionRequired => "command_info";
 
@@ -14,14 +16,15 @@ internal class InfoCommand : IChatCommand
 
     public string Description => "Displays generic information that everybody loves to see.";
 
-    public InfoCommand(IGameClientManager gameClientManager, IRoomManager roomManager)
+    public InfoCommand(IGameClientManager gameClientManager, IRoomManager roomManager, IPlusEnvironment environment)
     {
         _gameClientManager = gameClientManager;
         _roomManager = roomManager;
+        _environment = environment;
     }
     public void Execute(GameClient session, Room room, string[] parameters)
     {
-        var uptime = DateTime.Now - PlusEnvironment.ServerStarted;
+        var uptime = DateTime.Now - _environment.ServerStarted;
         var onlineUsers = _gameClientManager.Count;
         var roomCount = _roomManager.Count;
         session.Send(new RoomNotificationComposer("Powered by Plus++ Emulator",

--- a/IPlusEnvironment.cs
+++ b/IPlusEnvironment.cs
@@ -21,4 +21,5 @@ public interface IPlusEnvironment
     IFigureDataManager FigureManager { get; }
     ICollection<Habbo> CachedUsers { get; }
     bool RemoveFromCache(int id, out Habbo data);
+    DateTime ServerStarted { get; }
 }

--- a/PlusEnvironment.cs
+++ b/PlusEnvironment.cs
@@ -45,7 +45,7 @@ public class PlusEnvironment : IPlusEnvironment
     private readonly IFigureDataManager _figureManager;
     private readonly IItemDataManager _itemDataManager;
 
-    public static DateTime ServerStarted;
+    public DateTime ServerStarted { get; private set; }
 
     private static readonly List<char> Allowedchars = new(new[]
     {
@@ -338,6 +338,7 @@ public class PlusEnvironment : IPlusEnvironment
     IFigureDataManager IPlusEnvironment.FigureManager => _figureManager;
     ICollection<Habbo> IPlusEnvironment.CachedUsers => CachedUsers;
     bool IPlusEnvironment.RemoveFromCache(int id, out Habbo data) => RemoveFromCache(id, out data);
+    DateTime IPlusEnvironment.ServerStarted => ServerStarted;
 
     [Obsolete("Use dependency injection instead and inject required services.")]
     public static IGame Game => Instance!._game;


### PR DESCRIPTION
## Summary
- expose server start time in IPlusEnvironment
- store start time as instance property
- inject IPlusEnvironment for uptime in commands and server status

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688cb8f67fe083239bf9ee80c327a9dd