### PR TITLE
Refactor uptime access via DI

### DIFF
--- a/Communication/Packets/Incoming/Catalog/GetGroupFurniConfigEvent.cs
+++ b/Communication/Packets/Incoming/Catalog/GetGroupFurniConfigEvent.cs
@@ -15,7 +15,7 @@ internal class GetGroupFurniConfigEvent : IPacketEvent
 
     public Task Parse(GameClient session, IIncomingPacket packet)
     {
-        session.Send(new GroupFurniConfigComposer(_groupManager.GetGroupsForUser(session.GetHabbo().Id)));
+        session.Send(new GroupFurniConfigComposer(_groupManager.GetGroupsForUser(session.GetHabbo().Id), _groupManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Incoming/Groups/JoinGroupEvent.cs
+++ b/Communication/Packets/Incoming/Groups/JoinGroupEvent.cs
@@ -43,7 +43,7 @@ internal class JoinGroupEvent : IPacketEvent
         }
         else
         {
-            session.Send(new GroupFurniConfigComposer(_groupManager.GetGroupsForUser(session.GetHabbo().Id)));
+            session.Send(new GroupFurniConfigComposer(_groupManager.GetGroupsForUser(session.GetHabbo().Id), _groupManager));
             session.Send(new GroupInfoComposer(group, session, _userDataFactory));
             if (session.GetHabbo().CurrentRoom != null)
                 session.GetHabbo().CurrentRoom.SendPacket(new RefreshFavouriteGroupComposer(session.GetHabbo().Id));

--- a/Communication/Packets/Incoming/Quests/GetCurrentQuestEvent.cs
+++ b/Communication/Packets/Incoming/Quests/GetCurrentQuestEvent.cs
@@ -31,7 +31,7 @@ internal class GetCurrentQuestEvent : IPacketEvent
         }
         session.GetHabbo().HabboStats.QuestId = nextQuest.Id;
         _questManager.GetList(session, null);
-        session.Send(new QuestStartedComposer(session, nextQuest));
+        session.Send(new QuestStartedComposer(session, nextQuest, _questManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Incoming/Quests/StartQuestEvent.cs
+++ b/Communication/Packets/Incoming/Quests/StartQuestEvent.cs
@@ -29,7 +29,7 @@ internal class StartQuestEvent : IPacketEvent
         }
         session.GetHabbo().HabboStats.QuestId = quest.Id;
         _questManager.GetList(session, null);
-        session.Send(new QuestStartedComposer(session, quest));
+        session.Send(new QuestStartedComposer(session, quest, _questManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Incoming/Rooms/AI/Pets/GetPetInformationEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/AI/Pets/GetPetInformationEvent.cs
@@ -1,10 +1,18 @@
 ﻿using Plus.Communication.Packets.Outgoing.Rooms.AI.Pets;
 using Plus.HabboHotel.GameClients;
+using Plus.HabboHotel.Rooms;
 
 namespace Plus.Communication.Packets.Incoming.Rooms.AI.Pets;
 
 internal class GetPetInformationEvent : IPacketEvent
 {
+    private readonly IRoomManager _roomManager;
+
+    public GetPetInformationEvent(IRoomManager roomManager)
+    {
+        _roomManager = roomManager;
+    }
+
     public Task Parse(GameClient session, IIncomingPacket packet)
     {
         if (!session.GetHabbo().InRoom)
@@ -29,7 +37,7 @@ internal class GetPetInformationEvent : IPacketEvent
         //Continue as a regular pet..
         if (pet.RoomId != session.GetHabbo().CurrentRoom?.RoomId || pet.PetData == null)
             return Task.CompletedTask;
-        session.Send(new PetInformationComposer(pet.PetData));
+        session.Send(new PetInformationComposer(pet.PetData, _roomManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Incoming/Rooms/AI/Pets/Horse/ModifyWhoCanRideHorseEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/AI/Pets/Horse/ModifyWhoCanRideHorseEvent.cs
@@ -8,10 +8,12 @@ namespace Plus.Communication.Packets.Incoming.Rooms.AI.Pets.Horse;
 internal class ModifyWhoCanRideHorseEvent : RoomPacketEvent
 {
     private readonly IDatabase _database;
+    private readonly IRoomManager _roomManager;
 
-    public ModifyWhoCanRideHorseEvent(IDatabase database)
+    public ModifyWhoCanRideHorseEvent(IDatabase database, IRoomManager roomManager)
     {
         _database = database;
+        _roomManager = roomManager;
     }
 
     public override Task Parse(Room room, GameClient session, IIncomingPacket packet)
@@ -24,7 +26,7 @@ internal class ModifyWhoCanRideHorseEvent : RoomPacketEvent
         {
             dbClient.RunQuery($"UPDATE `bots_petdata` SET `anyone_ride` = '{pet.PetData.AnyoneCanRide}' WHERE `id` = '{petId}' LIMIT 1");
         }
-        room.SendPacket(new PetInformationComposer(pet.PetData));
+        room.SendPacket(new PetInformationComposer(pet.PetData, _roomManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Outgoing/Catalog/GroupFurniConfigComposer.cs
+++ b/Communication/Packets/Outgoing/Catalog/GroupFurniConfigComposer.cs
@@ -6,11 +6,13 @@ namespace Plus.Communication.Packets.Outgoing.Catalog;
 public class GroupFurniConfigComposer : IServerPacket
 {
     private readonly ICollection<Group> _groups;
+    private readonly IGroupManager _groupManager;
     public uint MessageId => ServerPacketHeader.GroupFurniConfigComposer;
 
-    public GroupFurniConfigComposer(ICollection<Group> groups)
+    public GroupFurniConfigComposer(ICollection<Group> groups, IGroupManager groupManager)
     {
         _groups = groups;
+        _groupManager = groupManager;
     }
 
     public void Compose(IOutgoingPacket packet)
@@ -21,8 +23,8 @@ public class GroupFurniConfigComposer : IServerPacket
             packet.WriteInteger(group.Id);
             packet.WriteString(group.Name);
             packet.WriteString(group.Badge);
-            packet.WriteString(PlusEnvironment.Game.GroupManager.GetColourCode(group.Colour1, true)); // TODO @80O: Pass by constructor / attach to Group object
-            packet.WriteString(PlusEnvironment.Game.GroupManager.GetColourCode(group.Colour2, false)); // TODO @80O: Pass by constructor / attach to Group object
+            packet.WriteString(_groupManager.GetColourCode(group.Colour1, true));
+            packet.WriteString(_groupManager.GetColourCode(group.Colour2, false));
             packet.WriteBoolean(false);
             packet.WriteInteger(group.CreatorId);
             packet.WriteBoolean(group.ForumEnabled);

--- a/Communication/Packets/Outgoing/Game/GameListComposer.cs
+++ b/Communication/Packets/Outgoing/Game/GameListComposer.cs
@@ -15,7 +15,7 @@ public class GameListComposer : IServerPacket
 
     public void Compose(IOutgoingPacket packet)
     {
-        packet.WriteInteger(PlusEnvironment.Game.GameDataManager.GetCount()); //Game count
+        packet.WriteInteger(_games.Count); // Game count
         foreach (var game in _games)
         {
             packet.WriteInteger(game.Id);

--- a/Communication/Packets/Outgoing/Quests/QuestCompletedComposer.cs
+++ b/Communication/Packets/Outgoing/Quests/QuestCompletedComposer.cs
@@ -7,18 +7,20 @@ public class QuestCompletedComposer : IServerPacket
 {
     private readonly GameClient _session;
     private readonly Quest _quest;
+    private readonly IQuestManager _questManager;
 
     public uint MessageId => ServerPacketHeader.QuestCompletedComposer;
 
-    public QuestCompletedComposer(GameClient session, Quest quest)
+    public QuestCompletedComposer(GameClient session, Quest quest, IQuestManager questManager)
     {
         _session = session;
         _quest = quest;
+        _questManager = questManager;
     }
 
     public void Compose(IOutgoingPacket packet)
     {
-        var amountInCat = PlusEnvironment.Game.QuestManager.GetAmountOfQuestsInCategory(_quest.Category);
+        var amountInCat = _questManager.GetAmountOfQuestsInCategory(_quest.Category);
         var number = _quest?.Number ?? amountInCat;
         var userProgress = _quest == null ? 0 : _session.GetHabbo().GetQuestProgress(_quest.Id);
         packet.WriteString(_quest.Category);

--- a/Communication/Packets/Outgoing/Quests/QuestListComposer.cs
+++ b/Communication/Packets/Outgoing/Quests/QuestListComposer.cs
@@ -8,13 +8,15 @@ public class QuestListComposer : IServerPacket
     private readonly GameClient _session;
     private readonly bool _send;
     private readonly Dictionary<string, Quest> _userQuests;
+    private readonly IQuestManager _questManager;
     public uint MessageId => ServerPacketHeader.QuestListComposer;
 
-    public QuestListComposer(GameClient session, bool send, Dictionary<string, Quest> userQuests)
+    public QuestListComposer(GameClient session, bool send, Dictionary<string, Quest> userQuests, IQuestManager questManager)
     {
         _session = session;
         _send = send;
         _userQuests = userQuests;
+        _questManager = questManager;
     }
 
     public void Compose(IOutgoingPacket packet)
@@ -43,7 +45,7 @@ public class QuestListComposer : IServerPacket
     {
         if (message == null || session == null)
             return;
-        var amountInCat = PlusEnvironment.Game.QuestManager.GetAmountOfQuestsInCategory(category);
+        var amountInCat = _questManager.GetAmountOfQuestsInCategory(category);
         var number = quest == null ? amountInCat : quest.Number - 1;
         var userProgress = quest == null ? 0 : session.GetHabbo().GetQuestProgress(quest.Id);
         if (quest != null && quest.IsCompleted(userProgress))

--- a/Communication/Packets/Outgoing/Quests/QuestStartedComposer.cs
+++ b/Communication/Packets/Outgoing/Quests/QuestStartedComposer.cs
@@ -7,12 +7,14 @@ public class QuestStartedComposer : IServerPacket
 {
     private readonly GameClient _session;
     private readonly Quest _quest;
+    private readonly IQuestManager _questManager;
     public uint MessageId => ServerPacketHeader.QuestStartedComposer;
 
-    public QuestStartedComposer(GameClient session, Quest quest)
+    public QuestStartedComposer(GameClient session, Quest quest, IQuestManager questManager)
     {
         _session = session;
         _quest = quest;
+        _questManager = questManager;
     }
 
     public void Compose(IOutgoingPacket packet)
@@ -24,7 +26,7 @@ public class QuestStartedComposer : IServerPacket
     {
         if (packet == null || session == null)
             return;
-        var amountInCat = PlusEnvironment.Game.QuestManager.GetAmountOfQuestsInCategory(quest.Category);
+        var amountInCat = _questManager.GetAmountOfQuestsInCategory(quest.Category);
         var number = quest == null ? amountInCat : quest.Number - 1;
         var userProgress = quest == null ? 0 : session.GetHabbo().GetQuestProgress(quest.Id);
         if (quest != null && quest.IsCompleted(userProgress))

--- a/Communication/Packets/Outgoing/Rooms/AI/Pets/PetInformationComposer.cs
+++ b/Communication/Packets/Outgoing/Rooms/AI/Pets/PetInformationComposer.cs
@@ -1,6 +1,7 @@
 ﻿using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Rooms.AI;
 using Plus.HabboHotel.Users;
+using Plus.HabboHotel.Rooms;
 using Plus.Utilities;
 
 namespace Plus.Communication.Packets.Outgoing.Rooms.AI.Pets;
@@ -9,19 +10,21 @@ public class PetInformationComposer : IServerPacket
 {
     private readonly Habbo? _habbo;
     private readonly Pet? _pet;
+    private readonly IRoomManager _roomManager;
 
     public uint MessageId => ServerPacketHeader.PetInformationComposer;
 
-    public PetInformationComposer(Pet pet)
+    public PetInformationComposer(Pet pet, IRoomManager roomManager)
     {
         _pet = pet;
+        _roomManager = roomManager;
     }
 
     public void Compose(IOutgoingPacket packet)
     {
         if (_pet != null)
         {
-            if (!PlusEnvironment.Game.RoomManager.TryGetRoom(_pet.RoomId, out var room))
+            if (!_roomManager.TryGetRoom(_pet.RoomId, out var room))
                 return;
             packet.WriteInteger(_pet.PetId);
             packet.WriteString(_pet.Name);

--- a/Core/ServerStatusUpdater.cs
+++ b/Core/ServerStatusUpdater.cs
@@ -2,6 +2,7 @@
 using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Rooms;
+using Plus;
 
 namespace Plus.Core;
 
@@ -12,13 +13,15 @@ public class ServerStatusUpdater : IDisposable, IServerStatusUpdater
     private readonly IDatabase _database;
     private readonly IGameClientManager _gameClientManager;
     private readonly IRoomManager _roomManager;
+    private readonly IPlusEnvironment _environment;
 
-    public ServerStatusUpdater(ILogger<ServerStatusUpdater> logger, IDatabase database, IGameClientManager gameClientManager, IRoomManager roomManager)
+    public ServerStatusUpdater(ILogger<ServerStatusUpdater> logger, IDatabase database, IGameClientManager gameClientManager, IRoomManager roomManager, IPlusEnvironment environment)
     {
         _logger = logger;
         _database = database;
         _gameClientManager = gameClientManager;
         _roomManager = roomManager;
+        _environment = environment;
     }
 
     private Timer _timer;
@@ -47,7 +50,7 @@ public class ServerStatusUpdater : IDisposable, IServerStatusUpdater
 
     private void UpdateOnlineUsers()
     {
-        var uptime = DateTime.Now - PlusEnvironment.ServerStarted;
+        var uptime = DateTime.Now - _environment.ServerStarted;
         var usersOnline = _gameClientManager.Count;
         var roomCount = _roomManager.Count;
         Console.Title = $"Plus Emulator - {usersOnline} users online - {roomCount} rooms loaded - {uptime.Days} day(s) {uptime.Hours} hour(s) uptime";

--- a/HabboHotel/Quests/QuestManager.cs
+++ b/HabboHotel/Quests/QuestManager.cs
@@ -125,13 +125,13 @@ public class QuestManager : IQuestManager
                 dbClient.RunQuery($"UPDATE `user_statistics` SET `quest_id` = '0' WHERE `id` = '{session.GetHabbo().Id}' LIMIT 1");
         }
         session.GetHabbo().Quests[session.GetHabbo().HabboStats.QuestId] = totalProgress;
-        session.Send(new QuestStartedComposer(session, quest));
+        session.Send(new QuestStartedComposer(session, quest, this));
         if (completeQuest)
         {
             _messengerDataLoader.BroadcastStatusUpdate(session.GetHabbo(), MessengerEventTypes.QuestCompleted, $"{quest.Category}.{quest.Name}");
             session.GetHabbo().HabboStats.QuestId = 0;
             session.GetHabbo().QuestLastCompleted = quest.Id;
-            session.Send(new QuestCompletedComposer(session, quest));
+            session.Send(new QuestCompletedComposer(session, quest, this));
             session.GetHabbo().Duckets += quest.Reward;
             session.Send(new HabboActivityPointNotificationComposer(session.GetHabbo().Duckets, quest.Reward));
             GetList(session, null);
@@ -178,7 +178,7 @@ public class QuestManager : IQuestManager
                 }
             }
         }
-        session.Send(new QuestListComposer(session, message != null, userQuests));
+        session.Send(new QuestListComposer(session, message != null, userQuests, this));
     }
 
     public void QuestReminder(GameClient session, int questId)
@@ -186,6 +186,6 @@ public class QuestManager : IQuestManager
         var quest = GetQuest(questId);
         if (quest == null)
             return;
-        session.Send(new QuestStartedComposer(session, quest));
+        session.Send(new QuestStartedComposer(session, quest, this));
     }
 }

--- a/HabboHotel/Rooms/Chat/Commands/User/InfoCommand.cs
+++ b/HabboHotel/Rooms/Chat/Commands/User/InfoCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Plus.Communication.Packets.Outgoing.Rooms.Notifications;
 using Plus.HabboHotel.GameClients;
+using Plus;
 
 namespace Plus.HabboHotel.Rooms.Chat.Commands.User;
 
@@ -7,6 +8,7 @@ internal class InfoCommand : IChatCommand
 {
     private readonly IGameClientManager _gameClientManager;
     private readonly IRoomManager _roomManager;
+    private readonly IPlusEnvironment _environment;
     public string Key => "about";
     public string PermissionRequired => "command_info";
 
@@ -14,14 +16,15 @@ internal class InfoCommand : IChatCommand
 
     public string Description => "Displays generic information that everybody loves to see.";
 
-    public InfoCommand(IGameClientManager gameClientManager, IRoomManager roomManager)
+    public InfoCommand(IGameClientManager gameClientManager, IRoomManager roomManager, IPlusEnvironment environment)
     {
         _gameClientManager = gameClientManager;
         _roomManager = roomManager;
+        _environment = environment;
     }
     public void Execute(GameClient session, Room room, string[] parameters)
     {
-        var uptime = DateTime.Now - PlusEnvironment.ServerStarted;
+        var uptime = DateTime.Now - _environment.ServerStarted;
         var onlineUsers = _gameClientManager.Count;
         var roomCount = _roomManager.Count;
         session.Send(new RoomNotificationComposer("Powered by Plus++ Emulator",

--- a/IPlusEnvironment.cs
+++ b/IPlusEnvironment.cs
@@ -21,4 +21,5 @@ public interface IPlusEnvironment
     IFigureDataManager FigureManager { get; }
     ICollection<Habbo> CachedUsers { get; }
     bool RemoveFromCache(int id, out Habbo data);
+    DateTime ServerStarted { get; }
 }

--- a/PlusEnvironment.cs
+++ b/PlusEnvironment.cs
@@ -45,7 +45,7 @@ public class PlusEnvironment : IPlusEnvironment
     private readonly IFigureDataManager _figureManager;
     private readonly IItemDataManager _itemDataManager;
 
-    public static DateTime ServerStarted;
+    public DateTime ServerStarted { get; private set; }
 
     private static readonly List<char> Allowedchars = new(new[]
     {
@@ -338,6 +338,7 @@ public class PlusEnvironment : IPlusEnvironment
     IFigureDataManager IPlusEnvironment.FigureManager => _figureManager;
     ICollection<Habbo> IPlusEnvironment.CachedUsers => CachedUsers;
     bool IPlusEnvironment.RemoveFromCache(int id, out Habbo data) => RemoveFromCache(id, out data);
+    DateTime IPlusEnvironment.ServerStarted => ServerStarted;
 
     [Obsolete("Use dependency injection instead and inject required services.")]
     public static IGame Game => Instance!._game;


### PR DESCRIPTION
## Summary
- expose server start time in IPlusEnvironment
- store start time as instance property
- inject IPlusEnvironment for uptime in commands and server status
- inject managers into quest and group packets to remove static references

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet format "Plus Emulator.sln" --verify-no-changes` *(fails: whitespace issues)*

------
https://chatgpt.com/codex/tasks/task_e_688cb8f67fe083239bf9ee80c327a9dd