### PR TITLE
Inject user data factory for user lookups

### DIFF
--- a/Communication/Packets/Incoming/Catalog/GetGroupFurniConfigEvent.cs
+++ b/Communication/Packets/Incoming/Catalog/GetGroupFurniConfigEvent.cs
@@ -15,7 +15,7 @@ internal class GetGroupFurniConfigEvent : IPacketEvent
 
     public Task Parse(GameClient session, IIncomingPacket packet)
     {
-        session.Send(new GroupFurniConfigComposer(_groupManager.GetGroupsForUser(session.GetHabbo().Id)));
+        session.Send(new GroupFurniConfigComposer(_groupManager.GetGroupsForUser(session.GetHabbo().Id), _groupManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Incoming/Groups/AcceptGroupMembershipEvent.cs
+++ b/Communication/Packets/Incoming/Groups/AcceptGroupMembershipEvent.cs
@@ -1,16 +1,19 @@
 ﻿using Plus.Communication.Packets.Outgoing.Groups;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Groups;
 
 internal class AcceptGroupMembershipEvent : IPacketEvent
 {
     private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public AcceptGroupMembershipEvent(IGroupManager groupManager)
+    public AcceptGroupMembershipEvent(IGroupManager groupManager, IUserDataFactory userDataFactory)
     {
         _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -23,7 +26,7 @@ internal class AcceptGroupMembershipEvent : IPacketEvent
             return Task.CompletedTask;
         if (!group.HasRequest(userId))
             return Task.CompletedTask;
-        var habbo = PlusEnvironment.GetHabboById(userId);
+        var habbo = _userDataFactory.GetUserDataByIdAsync(userId).Result;
         if (habbo == null)
         {
             session.SendNotification("Oops, an error occurred whilst finding this user.");

--- a/Communication/Packets/Incoming/Groups/GiveAdminRightsEvent.cs
+++ b/Communication/Packets/Incoming/Groups/GiveAdminRightsEvent.cs
@@ -3,6 +3,7 @@ using Plus.Communication.Packets.Outgoing.Rooms.Permissions;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Groups;
 using Plus.HabboHotel.Rooms;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Groups;
 
@@ -10,11 +11,13 @@ internal class GiveAdminRightsEvent : IPacketEvent
 {
     private readonly IGroupManager _groupManager;
     private readonly IRoomManager _roomManager;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public GiveAdminRightsEvent(IGroupManager groupManager, IRoomManager roomManager)
+    public GiveAdminRightsEvent(IGroupManager groupManager, IRoomManager roomManager, IUserDataFactory userDataFactory)
     {
         _groupManager = groupManager;
         _roomManager = roomManager;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -25,7 +28,7 @@ internal class GiveAdminRightsEvent : IPacketEvent
             return Task.CompletedTask;
         if (session.GetHabbo().Id != group.CreatorId || !group.IsMember(userId))
             return Task.CompletedTask;
-        var habbo = PlusEnvironment.GetHabboById(userId);
+        var habbo = _userDataFactory.GetUserDataByIdAsync(userId).Result;
         if (habbo == null)
         {
             session.SendNotification("Oops, an error occurred whilst finding this user.");

--- a/Communication/Packets/Incoming/Groups/JoinGroupEvent.cs
+++ b/Communication/Packets/Incoming/Groups/JoinGroupEvent.cs
@@ -43,7 +43,7 @@ internal class JoinGroupEvent : IPacketEvent
         }
         else
         {
-            session.Send(new GroupFurniConfigComposer(_groupManager.GetGroupsForUser(session.GetHabbo().Id)));
+            session.Send(new GroupFurniConfigComposer(_groupManager.GetGroupsForUser(session.GetHabbo().Id), _groupManager));
             session.Send(new GroupInfoComposer(group, session, _userDataFactory));
             if (session.GetHabbo().CurrentRoom != null)
                 session.GetHabbo().CurrentRoom.SendPacket(new RefreshFavouriteGroupComposer(session.GetHabbo().Id));

--- a/Communication/Packets/Incoming/Groups/TakeAdminRightsEvent.cs
+++ b/Communication/Packets/Incoming/Groups/TakeAdminRightsEvent.cs
@@ -3,6 +3,7 @@ using Plus.Communication.Packets.Outgoing.Rooms.Permissions;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Groups;
 using Plus.HabboHotel.Rooms;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Groups;
 
@@ -10,11 +11,13 @@ internal class TakeAdminRightsEvent : IPacketEvent
 {
     private readonly IGroupManager _groupManager;
     private readonly IRoomManager _roomManager;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public TakeAdminRightsEvent(IGroupManager groupManager, IRoomManager roomManager)
+    public TakeAdminRightsEvent(IGroupManager groupManager, IRoomManager roomManager, IUserDataFactory userDataFactory)
     {
         _groupManager = groupManager;
         _roomManager = roomManager;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -25,7 +28,7 @@ internal class TakeAdminRightsEvent : IPacketEvent
             return Task.CompletedTask;
         if (session.GetHabbo().Id != group.CreatorId || !group.IsMember(userId))
             return Task.CompletedTask;
-        var habbo = PlusEnvironment.GetHabboById(userId);
+        var habbo = _userDataFactory.GetUserDataByIdAsync(userId).Result;
         if (habbo == null)
         {
             session.SendNotification("Oops, an error occurred whilst finding this user.");

--- a/Communication/Packets/Incoming/Moderation/GetModeratorRoomChatlogEvent.cs
+++ b/Communication/Packets/Incoming/Moderation/GetModeratorRoomChatlogEvent.cs
@@ -4,6 +4,7 @@ using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Rooms;
 using Plus.HabboHotel.Rooms.Chat.Logs;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Moderation;
 
@@ -12,12 +13,14 @@ internal class GetModeratorRoomChatlogEvent : IPacketEvent
     private readonly IRoomManager _roomManager;
     private readonly IChatlogManager _chatlogManager;
     private readonly IDatabase _database;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public GetModeratorRoomChatlogEvent(IRoomManager roomManager, IChatlogManager chatlogManager, IDatabase database)
+    public GetModeratorRoomChatlogEvent(IRoomManager roomManager, IChatlogManager chatlogManager, IDatabase database, IUserDataFactory userDataFactory)
     {
         _roomManager = roomManager;
         _chatlogManager = chatlogManager;
         _database = database;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -38,7 +41,7 @@ internal class GetModeratorRoomChatlogEvent : IPacketEvent
             {
                 foreach (DataRow row in data.Rows)
                 {
-                    var habbo = PlusEnvironment.GetHabboById(Convert.ToInt32(row["user_id"]));
+                    var habbo = _userDataFactory.GetUserDataByIdAsync(Convert.ToInt32(row["user_id"])).Result;
                     if (habbo != null) chats.Add(new(Convert.ToInt32(row["user_id"]), roomId, Convert.ToString(row["message"]), Convert.ToDouble(row["timestamp"]), habbo));
                 }
             }

--- a/Communication/Packets/Incoming/Moderation/ModerationBanEvent.cs
+++ b/Communication/Packets/Incoming/Moderation/ModerationBanEvent.cs
@@ -1,6 +1,7 @@
 ﻿using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Moderation;
+using Plus.HabboHotel.Users.UserData;
 using Plus.Utilities;
 
 namespace Plus.Communication.Packets.Incoming.Moderation;
@@ -10,12 +11,14 @@ internal class ModerationBanEvent : IPacketEvent
     private readonly IGameClientManager _clientManager;
     private readonly IModerationManager _moderationManager;
     private readonly IDatabase _database;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public ModerationBanEvent(IGameClientManager clientManager, IModerationManager moderationManager, IDatabase database)
+    public ModerationBanEvent(IGameClientManager clientManager, IModerationManager moderationManager, IDatabase database, IUserDataFactory userDataFactory)
     {
         _clientManager = clientManager;
         _moderationManager = moderationManager;
         _database = database;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -31,7 +34,7 @@ internal class ModerationBanEvent : IPacketEvent
         var machineBan = packet.ReadBool();
         if (machineBan)
             ipBan = false;
-        var habbo = PlusEnvironment.GetHabboById(userId);
+        var habbo = _userDataFactory.GetUserDataByIdAsync(userId).Result;
         if (habbo == null)
         {
             session.SendWhisper("An error occoured whilst finding that user in the database.");

--- a/Communication/Packets/Incoming/Moderation/ModerationMuteEvent.cs
+++ b/Communication/Packets/Incoming/Moderation/ModerationMuteEvent.cs
@@ -1,15 +1,18 @@
 ﻿using Plus.Database;
 using Plus.HabboHotel.GameClients;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Moderation;
 
 internal class ModerationMuteEvent : IPacketEvent
 {
     public readonly IDatabase _database;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public ModerationMuteEvent(IDatabase database)
+    public ModerationMuteEvent(IDatabase database, IUserDataFactory userDataFactory)
     {
         _database = database;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -21,7 +24,7 @@ internal class ModerationMuteEvent : IPacketEvent
         double length = packet.ReadInt() * 60;
         packet.ReadString(); //unk1
         packet.ReadString(); //unk2
-        var habbo = PlusEnvironment.GetHabboById(userId);
+        var habbo = _userDataFactory.GetUserDataByIdAsync(userId).Result;
         if (habbo == null)
         {
             session.SendWhisper("An error occoured whilst finding that user in the database.");

--- a/Communication/Packets/Incoming/Moderation/ModerationTradeLockEvent.cs
+++ b/Communication/Packets/Incoming/Moderation/ModerationTradeLockEvent.cs
@@ -1,15 +1,19 @@
 ﻿using Plus.Database;
 using Plus.HabboHotel.GameClients;
+using Plus.HabboHotel.Users.UserData;
+using Plus.Utilities;
 
 namespace Plus.Communication.Packets.Incoming.Moderation;
 
 internal class ModerationTradeLockEvent : IPacketEvent
 {
     public readonly IDatabase _database;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public ModerationTradeLockEvent(IDatabase database)
+    public ModerationTradeLockEvent(IDatabase database, IUserDataFactory userDataFactory)
     {
         _database = database;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -21,8 +25,8 @@ internal class ModerationTradeLockEvent : IPacketEvent
         var days = packet.ReadInt() / 1440.0;
         packet.ReadString(); //unk1
         packet.ReadString(); //unk2
-        var length = PlusEnvironment.GetUnixTimestamp() + days * 86400;
-        var habbo = PlusEnvironment.GetHabboById(userId);
+        var length = UnixTimestamp.GetNow() + days * 86400;
+        var habbo = _userDataFactory.GetUserDataByIdAsync(userId).Result;
         if (habbo == null)
         {
             session.SendWhisper("An error occoured whilst finding that user in the database.");

--- a/Communication/Packets/Incoming/Moderation/SubmitNewTicketEvent.cs
+++ b/Communication/Packets/Incoming/Moderation/SubmitNewTicketEvent.cs
@@ -2,6 +2,7 @@
 using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Moderation;
+using Plus.HabboHotel.Users.UserData;
 using Plus.Utilities;
 
 namespace Plus.Communication.Packets.Incoming.Moderation;
@@ -11,12 +12,14 @@ internal class SubmitNewTicketEvent : IPacketEvent
     public readonly IModerationManager _moderationManager;
     public readonly IGameClientManager _clientManager;
     public readonly IDatabase _database;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public SubmitNewTicketEvent(IModerationManager moderationManager, IGameClientManager clientManager, IDatabase database)
+    public SubmitNewTicketEvent(IModerationManager moderationManager, IGameClientManager clientManager, IDatabase database, IUserDataFactory userDataFactory)
     {
         _moderationManager = moderationManager;
         _clientManager = clientManager;
         _database = database;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -36,7 +39,7 @@ internal class SubmitNewTicketEvent : IPacketEvent
         var category = packet.ReadInt();
         var reportedUserId = packet.ReadInt();
         var type = packet.ReadInt(); // Unsure on what this actually is.
-        var reportedUser = PlusEnvironment.GetHabboById(reportedUserId);
+        var reportedUser = _userDataFactory.GetUserDataByIdAsync(reportedUserId).Result;
         if (reportedUser == null)
         {
             // User doesn't exist.

--- a/Communication/Packets/Incoming/Quests/GetCurrentQuestEvent.cs
+++ b/Communication/Packets/Incoming/Quests/GetCurrentQuestEvent.cs
@@ -31,7 +31,7 @@ internal class GetCurrentQuestEvent : IPacketEvent
         }
         session.GetHabbo().HabboStats.QuestId = nextQuest.Id;
         _questManager.GetList(session, null);
-        session.Send(new QuestStartedComposer(session, nextQuest));
+        session.Send(new QuestStartedComposer(session, nextQuest, _questManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Incoming/Quests/StartQuestEvent.cs
+++ b/Communication/Packets/Incoming/Quests/StartQuestEvent.cs
@@ -29,7 +29,7 @@ internal class StartQuestEvent : IPacketEvent
         }
         session.GetHabbo().HabboStats.QuestId = quest.Id;
         _questManager.GetList(session, null);
-        session.Send(new QuestStartedComposer(session, quest));
+        session.Send(new QuestStartedComposer(session, quest, _questManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Incoming/Rooms/AI/Pets/GetPetInformationEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/AI/Pets/GetPetInformationEvent.cs
@@ -1,10 +1,18 @@
 ﻿using Plus.Communication.Packets.Outgoing.Rooms.AI.Pets;
 using Plus.HabboHotel.GameClients;
+using Plus.HabboHotel.Rooms;
 
 namespace Plus.Communication.Packets.Incoming.Rooms.AI.Pets;
 
 internal class GetPetInformationEvent : IPacketEvent
 {
+    private readonly IRoomManager _roomManager;
+
+    public GetPetInformationEvent(IRoomManager roomManager)
+    {
+        _roomManager = roomManager;
+    }
+
     public Task Parse(GameClient session, IIncomingPacket packet)
     {
         if (!session.GetHabbo().InRoom)
@@ -29,7 +37,7 @@ internal class GetPetInformationEvent : IPacketEvent
         //Continue as a regular pet..
         if (pet.RoomId != session.GetHabbo().CurrentRoom?.RoomId || pet.PetData == null)
             return Task.CompletedTask;
-        session.Send(new PetInformationComposer(pet.PetData));
+        session.Send(new PetInformationComposer(pet.PetData, _roomManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Incoming/Rooms/AI/Pets/Horse/ModifyWhoCanRideHorseEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/AI/Pets/Horse/ModifyWhoCanRideHorseEvent.cs
@@ -8,10 +8,12 @@ namespace Plus.Communication.Packets.Incoming.Rooms.AI.Pets.Horse;
 internal class ModifyWhoCanRideHorseEvent : RoomPacketEvent
 {
     private readonly IDatabase _database;
+    private readonly IRoomManager _roomManager;
 
-    public ModifyWhoCanRideHorseEvent(IDatabase database)
+    public ModifyWhoCanRideHorseEvent(IDatabase database, IRoomManager roomManager)
     {
         _database = database;
+        _roomManager = roomManager;
     }
 
     public override Task Parse(Room room, GameClient session, IIncomingPacket packet)
@@ -24,7 +26,7 @@ internal class ModifyWhoCanRideHorseEvent : RoomPacketEvent
         {
             dbClient.RunQuery($"UPDATE `bots_petdata` SET `anyone_ride` = '{pet.PetData.AnyoneCanRide}' WHERE `id` = '{petId}' LIMIT 1");
         }
-        room.SendPacket(new PetInformationComposer(pet.PetData));
+        room.SendPacket(new PetInformationComposer(pet.PetData, _roomManager));
         return Task.CompletedTask;
     }
 }

--- a/Communication/Packets/Outgoing/Catalog/GroupFurniConfigComposer.cs
+++ b/Communication/Packets/Outgoing/Catalog/GroupFurniConfigComposer.cs
@@ -6,11 +6,13 @@ namespace Plus.Communication.Packets.Outgoing.Catalog;
 public class GroupFurniConfigComposer : IServerPacket
 {
     private readonly ICollection<Group> _groups;
+    private readonly IGroupManager _groupManager;
     public uint MessageId => ServerPacketHeader.GroupFurniConfigComposer;
 
-    public GroupFurniConfigComposer(ICollection<Group> groups)
+    public GroupFurniConfigComposer(ICollection<Group> groups, IGroupManager groupManager)
     {
         _groups = groups;
+        _groupManager = groupManager;
     }
 
     public void Compose(IOutgoingPacket packet)
@@ -21,8 +23,8 @@ public class GroupFurniConfigComposer : IServerPacket
             packet.WriteInteger(group.Id);
             packet.WriteString(group.Name);
             packet.WriteString(group.Badge);
-            packet.WriteString(PlusEnvironment.Game.GroupManager.GetColourCode(group.Colour1, true)); // TODO @80O: Pass by constructor / attach to Group object
-            packet.WriteString(PlusEnvironment.Game.GroupManager.GetColourCode(group.Colour2, false)); // TODO @80O: Pass by constructor / attach to Group object
+            packet.WriteString(_groupManager.GetColourCode(group.Colour1, true));
+            packet.WriteString(_groupManager.GetColourCode(group.Colour2, false));
             packet.WriteBoolean(false);
             packet.WriteInteger(group.CreatorId);
             packet.WriteBoolean(group.ForumEnabled);

--- a/Communication/Packets/Outgoing/Game/GameListComposer.cs
+++ b/Communication/Packets/Outgoing/Game/GameListComposer.cs
@@ -15,7 +15,7 @@ public class GameListComposer : IServerPacket
 
     public void Compose(IOutgoingPacket packet)
     {
-        packet.WriteInteger(PlusEnvironment.Game.GameDataManager.GetCount()); //Game count
+        packet.WriteInteger(_games.Count); // Game count
         foreach (var game in _games)
         {
             packet.WriteInteger(game.Id);

--- a/Communication/Packets/Outgoing/Quests/QuestCompletedComposer.cs
+++ b/Communication/Packets/Outgoing/Quests/QuestCompletedComposer.cs
@@ -7,18 +7,20 @@ public class QuestCompletedComposer : IServerPacket
 {
     private readonly GameClient _session;
     private readonly Quest _quest;
+    private readonly IQuestManager _questManager;
 
     public uint MessageId => ServerPacketHeader.QuestCompletedComposer;
 
-    public QuestCompletedComposer(GameClient session, Quest quest)
+    public QuestCompletedComposer(GameClient session, Quest quest, IQuestManager questManager)
     {
         _session = session;
         _quest = quest;
+        _questManager = questManager;
     }
 
     public void Compose(IOutgoingPacket packet)
     {
-        var amountInCat = PlusEnvironment.Game.QuestManager.GetAmountOfQuestsInCategory(_quest.Category);
+        var amountInCat = _questManager.GetAmountOfQuestsInCategory(_quest.Category);
         var number = _quest?.Number ?? amountInCat;
         var userProgress = _quest == null ? 0 : _session.GetHabbo().GetQuestProgress(_quest.Id);
         packet.WriteString(_quest.Category);

--- a/Communication/Packets/Outgoing/Quests/QuestListComposer.cs
+++ b/Communication/Packets/Outgoing/Quests/QuestListComposer.cs
@@ -8,13 +8,15 @@ public class QuestListComposer : IServerPacket
     private readonly GameClient _session;
     private readonly bool _send;
     private readonly Dictionary<string, Quest> _userQuests;
+    private readonly IQuestManager _questManager;
     public uint MessageId => ServerPacketHeader.QuestListComposer;
 
-    public QuestListComposer(GameClient session, bool send, Dictionary<string, Quest> userQuests)
+    public QuestListComposer(GameClient session, bool send, Dictionary<string, Quest> userQuests, IQuestManager questManager)
     {
         _session = session;
         _send = send;
         _userQuests = userQuests;
+        _questManager = questManager;
     }
 
     public void Compose(IOutgoingPacket packet)
@@ -43,7 +45,7 @@ public class QuestListComposer : IServerPacket
     {
         if (message == null || session == null)
             return;
-        var amountInCat = PlusEnvironment.Game.QuestManager.GetAmountOfQuestsInCategory(category);
+        var amountInCat = _questManager.GetAmountOfQuestsInCategory(category);
         var number = quest == null ? amountInCat : quest.Number - 1;
         var userProgress = quest == null ? 0 : session.GetHabbo().GetQuestProgress(quest.Id);
         if (quest != null && quest.IsCompleted(userProgress))

--- a/Communication/Packets/Outgoing/Quests/QuestStartedComposer.cs
+++ b/Communication/Packets/Outgoing/Quests/QuestStartedComposer.cs
@@ -7,12 +7,14 @@ public class QuestStartedComposer : IServerPacket
 {
     private readonly GameClient _session;
     private readonly Quest _quest;
+    private readonly IQuestManager _questManager;
     public uint MessageId => ServerPacketHeader.QuestStartedComposer;
 
-    public QuestStartedComposer(GameClient session, Quest quest)
+    public QuestStartedComposer(GameClient session, Quest quest, IQuestManager questManager)
     {
         _session = session;
         _quest = quest;
+        _questManager = questManager;
     }
 
     public void Compose(IOutgoingPacket packet)
@@ -24,7 +26,7 @@ public class QuestStartedComposer : IServerPacket
     {
         if (packet == null || session == null)
             return;
-        var amountInCat = PlusEnvironment.Game.QuestManager.GetAmountOfQuestsInCategory(quest.Category);
+        var amountInCat = _questManager.GetAmountOfQuestsInCategory(quest.Category);
         var number = quest == null ? amountInCat : quest.Number - 1;
         var userProgress = quest == null ? 0 : session.GetHabbo().GetQuestProgress(quest.Id);
         if (quest != null && quest.IsCompleted(userProgress))

--- a/Communication/Packets/Outgoing/Rooms/AI/Pets/PetInformationComposer.cs
+++ b/Communication/Packets/Outgoing/Rooms/AI/Pets/PetInformationComposer.cs
@@ -1,6 +1,7 @@
 ﻿using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Rooms.AI;
 using Plus.HabboHotel.Users;
+using Plus.HabboHotel.Rooms;
 using Plus.Utilities;
 
 namespace Plus.Communication.Packets.Outgoing.Rooms.AI.Pets;
@@ -9,19 +10,21 @@ public class PetInformationComposer : IServerPacket
 {
     private readonly Habbo? _habbo;
     private readonly Pet? _pet;
+    private readonly IRoomManager _roomManager;
 
     public uint MessageId => ServerPacketHeader.PetInformationComposer;
 
-    public PetInformationComposer(Pet pet)
+    public PetInformationComposer(Pet pet, IRoomManager roomManager)
     {
         _pet = pet;
+        _roomManager = roomManager;
     }
 
     public void Compose(IOutgoingPacket packet)
     {
         if (_pet != null)
         {
-            if (!PlusEnvironment.Game.RoomManager.TryGetRoom(_pet.RoomId, out var room))
+            if (!_roomManager.TryGetRoom(_pet.RoomId, out var room))
                 return;
             packet.WriteInteger(_pet.PetId);
             packet.WriteString(_pet.Name);

--- a/Core/ServerStatusUpdater.cs
+++ b/Core/ServerStatusUpdater.cs
@@ -2,6 +2,7 @@
 using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Rooms;
+using Plus;
 
 namespace Plus.Core;
 
@@ -12,13 +13,15 @@ public class ServerStatusUpdater : IDisposable, IServerStatusUpdater
     private readonly IDatabase _database;
     private readonly IGameClientManager _gameClientManager;
     private readonly IRoomManager _roomManager;
+    private readonly IPlusEnvironment _environment;
 
-    public ServerStatusUpdater(ILogger<ServerStatusUpdater> logger, IDatabase database, IGameClientManager gameClientManager, IRoomManager roomManager)
+    public ServerStatusUpdater(ILogger<ServerStatusUpdater> logger, IDatabase database, IGameClientManager gameClientManager, IRoomManager roomManager, IPlusEnvironment environment)
     {
         _logger = logger;
         _database = database;
         _gameClientManager = gameClientManager;
         _roomManager = roomManager;
+        _environment = environment;
     }
 
     private Timer _timer;
@@ -47,7 +50,7 @@ public class ServerStatusUpdater : IDisposable, IServerStatusUpdater
 
     private void UpdateOnlineUsers()
     {
-        var uptime = DateTime.Now - PlusEnvironment.ServerStarted;
+        var uptime = DateTime.Now - _environment.ServerStarted;
         var usersOnline = _gameClientManager.Count;
         var roomCount = _roomManager.Count;
         Console.Title = $"Plus Emulator - {usersOnline} users online - {roomCount} rooms loaded - {uptime.Days} day(s) {uptime.Hours} hour(s) uptime";

--- a/HabboHotel/Quests/QuestManager.cs
+++ b/HabboHotel/Quests/QuestManager.cs
@@ -125,13 +125,13 @@ public class QuestManager : IQuestManager
                 dbClient.RunQuery($"UPDATE `user_statistics` SET `quest_id` = '0' WHERE `id` = '{session.GetHabbo().Id}' LIMIT 1");
         }
         session.GetHabbo().Quests[session.GetHabbo().HabboStats.QuestId] = totalProgress;
-        session.Send(new QuestStartedComposer(session, quest));
+        session.Send(new QuestStartedComposer(session, quest, this));
         if (completeQuest)
         {
             _messengerDataLoader.BroadcastStatusUpdate(session.GetHabbo(), MessengerEventTypes.QuestCompleted, $"{quest.Category}.{quest.Name}");
             session.GetHabbo().HabboStats.QuestId = 0;
             session.GetHabbo().QuestLastCompleted = quest.Id;
-            session.Send(new QuestCompletedComposer(session, quest));
+            session.Send(new QuestCompletedComposer(session, quest, this));
             session.GetHabbo().Duckets += quest.Reward;
             session.Send(new HabboActivityPointNotificationComposer(session.GetHabbo().Duckets, quest.Reward));
             GetList(session, null);
@@ -178,7 +178,7 @@ public class QuestManager : IQuestManager
                 }
             }
         }
-        session.Send(new QuestListComposer(session, message != null, userQuests));
+        session.Send(new QuestListComposer(session, message != null, userQuests, this));
     }
 
     public void QuestReminder(GameClient session, int questId)
@@ -186,6 +186,6 @@ public class QuestManager : IQuestManager
         var quest = GetQuest(questId);
         if (quest == null)
             return;
-        session.Send(new QuestStartedComposer(session, quest));
+        session.Send(new QuestStartedComposer(session, quest, this));
     }
 }

--- a/HabboHotel/Rooms/Chat/Commands/User/InfoCommand.cs
+++ b/HabboHotel/Rooms/Chat/Commands/User/InfoCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Plus.Communication.Packets.Outgoing.Rooms.Notifications;
 using Plus.HabboHotel.GameClients;
+using Plus;
 
 namespace Plus.HabboHotel.Rooms.Chat.Commands.User;
 
@@ -7,6 +8,7 @@ internal class InfoCommand : IChatCommand
 {
     private readonly IGameClientManager _gameClientManager;
     private readonly IRoomManager _roomManager;
+    private readonly IPlusEnvironment _environment;
     public string Key => "about";
     public string PermissionRequired => "command_info";
 
@@ -14,14 +16,15 @@ internal class InfoCommand : IChatCommand
 
     public string Description => "Displays generic information that everybody loves to see.";
 
-    public InfoCommand(IGameClientManager gameClientManager, IRoomManager roomManager)
+    public InfoCommand(IGameClientManager gameClientManager, IRoomManager roomManager, IPlusEnvironment environment)
     {
         _gameClientManager = gameClientManager;
         _roomManager = roomManager;
+        _environment = environment;
     }
     public void Execute(GameClient session, Room room, string[] parameters)
     {
-        var uptime = DateTime.Now - PlusEnvironment.ServerStarted;
+        var uptime = DateTime.Now - _environment.ServerStarted;
         var onlineUsers = _gameClientManager.Count;
         var roomCount = _roomManager.Count;
         session.Send(new RoomNotificationComposer("Powered by Plus++ Emulator",

--- a/IPlusEnvironment.cs
+++ b/IPlusEnvironment.cs
@@ -21,4 +21,5 @@ public interface IPlusEnvironment
     IFigureDataManager FigureManager { get; }
     ICollection<Habbo> CachedUsers { get; }
     bool RemoveFromCache(int id, out Habbo data);
+    DateTime ServerStarted { get; }
 }

--- a/PlusEnvironment.cs
+++ b/PlusEnvironment.cs
@@ -45,7 +45,7 @@ public class PlusEnvironment : IPlusEnvironment
     private readonly IFigureDataManager _figureManager;
     private readonly IItemDataManager _itemDataManager;
 
-    public static DateTime ServerStarted;
+    public DateTime ServerStarted { get; private set; }
 
     private static readonly List<char> Allowedchars = new(new[]
     {
@@ -338,6 +338,7 @@ public class PlusEnvironment : IPlusEnvironment
     IFigureDataManager IPlusEnvironment.FigureManager => _figureManager;
     ICollection<Habbo> IPlusEnvironment.CachedUsers => CachedUsers;
     bool IPlusEnvironment.RemoveFromCache(int id, out Habbo data) => RemoveFromCache(id, out data);
+    DateTime IPlusEnvironment.ServerStarted => ServerStarted;
 
     [Obsolete("Use dependency injection instead and inject required services.")]
     public static IGame Game => Instance!._game;


### PR DESCRIPTION
## Summary
- resolve group membership and admin changes via injected IUserDataFactory
- update moderation events to fetch Habbo via dependency injection
- use UnixTimestamp instead of PlusEnvironment for trade lock expiry

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`
- `dotnet format "Plus Emulator.sln" --verify-no-changes` *(fails: line endings)*

------
https://chatgpt.com/codex/tasks/task_e_688cb8f67fe083239bf9ee80c327a9dd