### PR TITLE
Reduce PlusEnvironment usages

### DIFF
--- a/Communication/Packets/Incoming/Catalog/PurchaseFromCatalogAsGiftEvent.cs
+++ b/Communication/Packets/Incoming/Catalog/PurchaseFromCatalogAsGiftEvent.cs
@@ -153,7 +153,7 @@ public class PurchaseFromCatalogAsGiftEvent : IPacketEvent
                     double number = 0;
                     try
                     {
-                        number = string.IsNullOrEmpty(data) ? 0 : double.Parse(data, PlusEnvironment.CultureInfo);
+                        number = string.IsNullOrEmpty(data) ? 0 : double.Parse(data, CultureInfo.InvariantCulture);
                     }
                     catch
                     {

--- a/Communication/Packets/Incoming/Catalog/PurchaseFromCatalogEvent.cs
+++ b/Communication/Packets/Incoming/Catalog/PurchaseFromCatalogEvent.cs
@@ -120,7 +120,7 @@ public class PurchaseFromCatalogEvent : IPacketEvent
                 double number = 0;
                 try
                 {
-                    number = string.IsNullOrEmpty(extraData) ? 0 : double.Parse(extraData, PlusEnvironment.CultureInfo);
+                    number = string.IsNullOrEmpty(extraData) ? 0 : double.Parse(extraData, CultureInfo.InvariantCulture);
                 }
                 catch (Exception e)
                 {

--- a/Communication/Packets/Incoming/ClientPacket.cs
+++ b/Communication/Packets/Incoming/ClientPacket.cs
@@ -1,4 +1,5 @@
 ﻿using Plus.Utilities;
+using System.Text;
 
 namespace Plus.Communication.Packets.Incoming;
 
@@ -25,7 +26,7 @@ public class ClientPacket
         _pointer = 0;
     }
 
-    public override string ToString() => $"[{Id}] BODY: {PlusEnvironment.GetDefaultEncoding().GetString(_body).Replace(Convert.ToChar(0).ToString(), "[0]")}";
+    public override string ToString() => $"[{Id}] BODY: {Encoding.Default.GetString(_body).Replace(Convert.ToChar(0).ToString(), "[0]")}";
 
     public void AdvancePointer(int i)
     {
@@ -57,7 +58,7 @@ public class ClientPacket
         return ReadBytes(len);
     }
 
-    public string PopString() => PlusEnvironment.GetDefaultEncoding().GetString(ReadFixedValue());
+    public string PopString() => Encoding.Default.GetString(ReadFixedValue());
 
     public bool PopBoolean() => RemainingLength > 0 && _body[_pointer++] == Convert.ToChar(1);
 

--- a/Communication/Packets/Incoming/Rooms/AI/Bots/SaveBotActionEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/AI/Bots/SaveBotActionEvent.cs
@@ -4,6 +4,8 @@ using Plus.Communication.Packets.Outgoing.Rooms.Avatar;
 using Plus.Communication.Packets.Outgoing.Rooms.Engine;
 using Plus.Database;
 using Plus.HabboHotel.GameClients;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 using Plus.Utilities;
 
 namespace Plus.Communication.Packets.Incoming.Rooms.AI.Bots;
@@ -11,9 +13,13 @@ namespace Plus.Communication.Packets.Incoming.Rooms.AI.Bots;
 internal class SaveBotActionEvent : IPacketEvent
 {
     private readonly IDatabase _database;
-    public SaveBotActionEvent(IDatabase database)
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
+    public SaveBotActionEvent(IDatabase database, IGroupManager groupManager, IUserDataFactory userDataFactory)
     {
         _database = database;
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -147,7 +153,7 @@ internal class SaveBotActionEvent : IPacketEvent
                     dbClient.AddParameter("name", dataString);
                     dbClient.RunQuery();
                 }
-                room.SendPacket(new UsersComposer(bot));
+                room.SendPacket(new UsersComposer(bot, _groupManager, _userDataFactory));
                 break;
             }
         }

--- a/Communication/Packets/Incoming/Rooms/AI/Pets/Horse/ApplyHorseEffectEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/AI/Pets/Horse/ApplyHorseEffectEvent.cs
@@ -4,16 +4,22 @@ using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Items;
 using Plus.HabboHotel.Rooms;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Rooms.AI.Pets.Horse;
 
 internal class ApplyHorseEffectEvent : RoomPacketEvent
 {
     private readonly IDatabase _database;
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public ApplyHorseEffectEvent(IDatabase database)
+    public ApplyHorseEffectEvent(IDatabase database, IGroupManager groupManager, IUserDataFactory userDataFactory)
     {
         _database = database;
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
     }
 
     public override Task Parse(Room room, GameClient session, IIncomingPacket packet)
@@ -106,7 +112,7 @@ internal class ApplyHorseEffectEvent : RoomPacketEvent
         }
 
         //Update the Pet and the Pet figure information.
-        room.SendPacket(new UsersComposer(petUser));
+        room.SendPacket(new UsersComposer(petUser, _groupManager, _userDataFactory));
         room.SendPacket(new PetHorseFigureInformationComposer(petUser));
         return Task.CompletedTask;
     }

--- a/Communication/Packets/Incoming/Rooms/AI/Pets/Horse/RemoveSaddleFromHorseEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/AI/Pets/Horse/RemoveSaddleFromHorseEvent.cs
@@ -7,6 +7,8 @@ using Plus.HabboHotel.Catalog.Utilities;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Items;
 using Plus.HabboHotel.Rooms;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Rooms.AI.Pets.Horse;
 
@@ -16,13 +18,17 @@ internal class RemoveSaddleFromHorseEvent : IPacketEvent
     private readonly IItemDataManager _itemDataManager;
     private readonly IDatabase _database;
     private readonly IItemFactory _itemFactory;
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public RemoveSaddleFromHorseEvent(IRoomManager roomManager, IItemDataManager itemDataManager, IDatabase database, IItemFactory itemFactory)
+    public RemoveSaddleFromHorseEvent(IRoomManager roomManager, IItemDataManager itemDataManager, IDatabase database, IItemFactory itemFactory, IGroupManager groupManager, IUserDataFactory userDataFactory)
     {
         _roomManager = roomManager;
         _itemDataManager = itemDataManager;
         _database = database;
         _itemFactory = itemFactory;
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
     }
 
     public Task Parse(GameClient session, IIncomingPacket packet)
@@ -60,7 +66,7 @@ internal class RemoveSaddleFromHorseEvent : IPacketEvent
         }
 
         //Update the Pet and the Pet figure information.
-        room.SendPacket(new UsersComposer(petUser));
+        room.SendPacket(new UsersComposer(petUser, _groupManager, _userDataFactory));
         room.SendPacket(new PetHorseFigureInformationComposer(petUser));
         return Task.CompletedTask;
     }

--- a/Communication/Packets/Incoming/Rooms/AI/Pets/PickUpPetEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/AI/Pets/PickUpPetEvent.cs
@@ -3,6 +3,8 @@ using Plus.Communication.Packets.Outgoing.Rooms.Engine;
 using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Rooms;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Rooms.AI.Pets;
 
@@ -10,11 +12,15 @@ internal class PickUpPetEvent : RoomPacketEvent
 {
     private readonly IGameClientManager _clientManager;
     private readonly IDatabase _database;
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public PickUpPetEvent(IGameClientManager clientManager, IDatabase database)
+    public PickUpPetEvent(IGameClientManager clientManager, IDatabase database, IGroupManager groupManager, IUserDataFactory userDataFactory)
     {
         _clientManager = clientManager;
         _database = database;
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
     }
 
     public override Task Parse(Room room, GameClient session, IIncomingPacket packet)
@@ -42,7 +48,7 @@ internal class PickUpPetEvent : RoomPacketEvent
             room.SendPacket(new UserRemoveComposer(targetUser.VirtualId));
 
             //Add the new one, they won't even notice a thing!!11 8-)
-            room.SendPacket(new UsersComposer(targetUser));
+            room.SendPacket(new UsersComposer(targetUser, _groupManager, _userDataFactory));
             return Task.CompletedTask;
         }
         if (session.GetHabbo().Id != pet.PetData.OwnerId && !room.CheckRights(session, true))

--- a/Communication/Packets/Incoming/Rooms/Action/AmbassadorAlertEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/Action/AmbassadorAlertEvent.cs
@@ -1,19 +1,25 @@
 ﻿using Plus.HabboHotel.GameClients;
 using Plus.HabboHotel.Ambassadors;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Rooms.Action;
 
 internal class AmbassadorAlertEvent : IPacketEvent
 {
     private readonly IAmbassadorsManager _ambassadorsManager;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public AmbassadorAlertEvent(IAmbassadorsManager ambassadorsManager) => _ambassadorsManager = ambassadorsManager;
+    public AmbassadorAlertEvent(IAmbassadorsManager ambassadorsManager, IUserDataFactory userDataFactory)
+    {
+        _ambassadorsManager = ambassadorsManager;
+        _userDataFactory = userDataFactory;
+    }
 
     public async Task Parse(GameClient session, IIncomingPacket packet)
     {
         var userid = packet.ReadInt();
-        var target = PlusEnvironment.GetHabboById(userid);
-
-        await _ambassadorsManager.Warn(session.GetHabbo(), target, "Alert");
+        var target = await _userDataFactory.GetUserDataByIdAsync(userid);
+        if (target != null)
+            await _ambassadorsManager.Warn(session.GetHabbo(), target, "Alert");
     }
 }

--- a/Communication/Packets/Incoming/Rooms/Action/MuteUserEvent.cs
+++ b/Communication/Packets/Incoming/Rooms/Action/MuteUserEvent.cs
@@ -1,46 +1,50 @@
 ﻿using Plus.HabboHotel.Achievements;
 using Plus.HabboHotel.GameClients;
 using Plus.Utilities;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.Communication.Packets.Incoming.Rooms.Action;
 
 internal class MuteUserEvent : IPacketEvent
 {
     private readonly IAchievementManager _achievementManager;
+    private readonly IUserDataFactory _userDataFactory;
 
-    public MuteUserEvent(IAchievementManager achievementManager)
+    public MuteUserEvent(IAchievementManager achievementManager, IUserDataFactory userDataFactory)
     {
         _achievementManager = achievementManager;
+        _userDataFactory = userDataFactory;
     }
 
-    public Task Parse(GameClient session, IIncomingPacket packet)
+    public async Task Parse(GameClient session, IIncomingPacket packet)
     {
         if (!session.GetHabbo().InRoom)
-            return Task.CompletedTask;
+            return;
         var userId = packet.ReadInt();
         packet.ReadInt(); //roomId
         var time = packet.ReadInt();
         var room = session.GetHabbo().CurrentRoom;
         if (room == null)
-            return Task.CompletedTask;
+            return;
         if (room.WhoCanMute == 0 && !room.CheckRights(session, true) && room.Group == null || room.WhoCanMute == 1 && !room.CheckRights(session) && room.Group == null ||
             room.Group != null && !room.CheckRights(session, false, true))
-            return Task.CompletedTask;
-        var target = room.GetRoomUserManager().GetRoomUserByHabbo(PlusEnvironment.GetUsernameById(userId));
+            return;
+        var username = await _userDataFactory.GetUsernameForHabboById(userId);
+        var target = room.GetRoomUserManager().GetRoomUserByHabbo(username);
         if (target == null)
-            return Task.CompletedTask;
+            return;
         if (target.GetClient().GetHabbo().Permissions.HasRight("mod_tool"))
-            return Task.CompletedTask;
+            return;
         if (room.MutedUsers.ContainsKey(userId))
         {
             if (room.MutedUsers[userId] < UnixTimestamp.GetNow())
                 room.MutedUsers.Remove(userId);
             else
-                return Task.CompletedTask;
+                return;
         }
         room.MutedUsers.Add(userId, UnixTimestamp.GetNow() + time * 60);
         target.GetClient().SendWhisper($"The room owner has muted you for {time} minutes!");
         _achievementManager.ProgressAchievement(session, "ACH_SelfModMuteSeen", 1);
-        return Task.CompletedTask;
+        return;
     }
 }

--- a/HabboHotel/Friends/MessengerDataLoader.cs
+++ b/HabboHotel/Friends/MessengerDataLoader.cs
@@ -94,7 +94,7 @@ internal class MessengerDataLoader : IMessengerDataLoader
     public async Task<Dictionary<int, List<(string Message, int SecondsAgo)>>> GetAndDeleteOfflineMessages(int userId)
     {
         using var connection = _database.Connection();
-        var messages = (await connection.QueryAsync<(int, string, int)>("SELECT from_id, message, timestamp FROM messenger_offline_messages WHERE to_id = @userId", new { userId })).GroupBy(r => r.Item1).ToDictionary(r => r.Key, r => r.OrderBy(r => r.Item3).Select(g => (g.Item2, (int)(PlusEnvironment.Now() - g.Item3))).ToList());
+        var messages = (await connection.QueryAsync<(int, string, int)>("SELECT from_id, message, timestamp FROM messenger_offline_messages WHERE to_id = @userId", new { userId })).GroupBy(r => r.Item1).ToDictionary(r => r.Key, r => r.OrderBy(r => r.Item3).Select(g => (g.Item2, (int)(DateTimeOffset.UtcNow.ToUnixTimeSeconds() - g.Item3))).ToList());
         await connection.ExecuteAsync("DELETE FROM messenger_offline_messages WHERE to_id = @userId", new { userId });
         return messages;
     }

--- a/HabboHotel/Moderation/ModerationManager.cs
+++ b/HabboHotel/Moderation/ModerationManager.cs
@@ -157,7 +157,7 @@ public sealed class ModerationManager : IModerationManager
                     var ban = new ModerationBan(BanTypeUtility.GetModerationBanType(type), value, reason, expires);
                     if (ban != null)
                     {
-                        if (expires > PlusEnvironment.GetUnixTimestamp())
+                        if (expires > DateTimeOffset.UtcNow.ToUnixTimeSeconds())
                         {
                             if (!_bans.ContainsKey(value))
                                 _bans.Add(value, ban);
@@ -198,7 +198,7 @@ public sealed class ModerationManager : IModerationManager
                     var ban = new ModerationBan(BanTypeUtility.GetModerationBanType(type), value, reason, expires);
                     if (ban != null)
                     {
-                        if (expires > PlusEnvironment.GetUnixTimestamp())
+                        if (expires > DateTimeOffset.UtcNow.ToUnixTimeSeconds())
                         {
                             if (!_bans.ContainsKey(value))
                                 _bans.Add(value, ban);
@@ -222,7 +222,7 @@ public sealed class ModerationManager : IModerationManager
         using (var dbClient = _database.GetQueryReactor())
         {
             dbClient.SetQuery(
-                $"REPLACE INTO `bans` (`bantype`, `value`, `reason`, `expire`, `added_by`,`added_date`) VALUES ('{banType}', '{banValue}', @reason, {expireTimestamp}, '{mod}', '{PlusEnvironment.GetUnixTimestamp()}');");
+                $"REPLACE INTO `bans` (`bantype`, `value`, `reason`, `expire`, `added_by`,`added_date`) VALUES ('{banType}', '{banValue}', @reason, {expireTimestamp}, '{mod}', '{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}');");
             dbClient.AddParameter("reason", reason);
             dbClient.RunQuery();
         }

--- a/HabboHotel/Rooms/Chat/Commands/CommandManager.cs
+++ b/HabboHotel/Rooms/Chat/Commands/CommandManager.cs
@@ -140,7 +140,7 @@ public class CommandManager : ICommandManager
         dbClient.AddParameter("UserId", userId);
         dbClient.AddParameter("Data", data);
         dbClient.AddParameter("MachineId", machineId ?? string.Empty);
-        dbClient.AddParameter("Timestamp", PlusEnvironment.GetUnixTimestamp());
+        dbClient.AddParameter("Timestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
         dbClient.RunQuery();
     }
 

--- a/HabboHotel/Rooms/Chat/Commands/Moderator/TradeBanCommand.cs
+++ b/HabboHotel/Rooms/Chat/Commands/Moderator/TradeBanCommand.cs
@@ -49,7 +49,7 @@ internal class TradeBanCommand : ITargetChatCommand
                 days = 1;
             if (days > 365)
                 days = 365;
-            var length = PlusEnvironment.GetUnixTimestamp() + days * 86400;
+            var length = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + days * 86400;
             using (var dbClient = _database.GetQueryReactor())
             {
                 dbClient.RunQuery($"UPDATE `user_info` SET `trading_locked` = '{length}', `trading_locks_count` = `trading_locks_count` + '1' WHERE `user_id` = '{target.Id}' LIMIT 1");

--- a/HabboHotel/Rooms/Chat/Commands/User/Fun/PetCommand.cs
+++ b/HabboHotel/Rooms/Chat/Commands/User/Fun/PetCommand.cs
@@ -1,10 +1,20 @@
 ﻿using Plus.Communication.Packets.Outgoing.Rooms.Engine;
 using Plus.HabboHotel.GameClients;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.HabboHotel.Rooms.Chat.Commands.User.Fun;
 
 internal class PetCommand : IChatCommand
 {
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
+
+    public PetCommand(IGroupManager groupManager, IUserDataFactory userDataFactory)
+    {
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
+    }
     public string Key => "pet";
     public string PermissionRequired => "command_pet";
 
@@ -30,7 +40,7 @@ internal class PetCommand : IChatCommand
                 room.SendPacket(new UserRemoveComposer(roomUser.VirtualId));
 
                 //Add the new one, they won't even notice a thing!!11 8-)
-                room.SendPacket(new UsersComposer(roomUser));
+                room.SendPacket(new UsersComposer(roomUser, _groupManager, _userDataFactory));
             }
             return;
         }
@@ -58,7 +68,7 @@ internal class PetCommand : IChatCommand
         room.SendPacket(new UserRemoveComposer(roomUser.VirtualId));
 
         //Add the new one, they won't even notice a thing!!11 8-)
-        room.SendPacket(new UsersComposer(roomUser));
+        room.SendPacket(new UsersComposer(roomUser, _groupManager, _userDataFactory));
 
         //Tell them a quick message.
         if (session.GetHabbo().PetId > 0)

--- a/HabboHotel/Rooms/Chat/Commands/User/RoomCommand.cs
+++ b/HabboHotel/Rooms/Chat/Commands/User/RoomCommand.cs
@@ -3,12 +3,16 @@ using Plus.Communication.Packets.Outgoing.Rooms.Engine;
 using Plus.Database;
 using Plus.HabboHotel.GameClients;
 using Plus.Utilities;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 
 namespace Plus.HabboHotel.Rooms.Chat.Commands.User;
 
 internal class RoomCommand : IChatCommand
 {
     private readonly IDatabase _database;
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
     public string Key => "room";
     public string PermissionRequired => "command_room";
 
@@ -16,9 +20,11 @@ internal class RoomCommand : IChatCommand
 
     public string Description => "Gives you the ability to enable or disable basic room commands.";
 
-    public RoomCommand(IDatabase database)
+    public RoomCommand(IDatabase database, IGroupManager groupManager, IUserDataFactory userDataFactory)
     {
         _database = database;
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
     }
 
     public void Execute(GameClient session, Room room, string[] parameters)
@@ -161,7 +167,7 @@ internal class RoomCommand : IChatCommand
                             room.SendPacket(new UserRemoveComposer(user.VirtualId));
 
                             //Add the new one, they won't even notice a thing!!11 8-)
-                            room.SendPacket(new UsersComposer(user));
+                            room.SendPacket(new UsersComposer(user, _groupManager, _userDataFactory));
                         }
                     }
                 }

--- a/HabboHotel/Rooms/Room.cs
+++ b/HabboHotel/Rooms/Room.cs
@@ -17,6 +17,8 @@ using Plus.HabboHotel.Rooms.Games.Freeze;
 using Plus.HabboHotel.Rooms.Games.Teams;
 using Plus.HabboHotel.Rooms.Instance;
 using Plus.Database;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 using Plus.Utilities;
 
 namespace Plus.HabboHotel.Rooms;
@@ -41,6 +43,8 @@ public class Room : RoomData
 
     private RoomUserManager _roomUserManager;
     private Soccer _soccer;
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
 
     public bool IsCrashed;
     public DateTime LastRegeneration;
@@ -60,10 +64,12 @@ public class Room : RoomData
 
     public List<int> UsersWithRights;
 
-    public Room(RoomData data, IDatabase database)
+    public Room(RoomData data, IDatabase database, IGroupManager groupManager, IUserDataFactory userDataFactory)
         : base(data)
     {
         _database = database;
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
         IsLagging = 0;
         Unloaded = false;
         IdleTime = 0;
@@ -72,7 +78,7 @@ public class Room : RoomData
         _tents = new();
         _gamemap = new(this, data.Model);
         _roomItemHandling = new(this);
-        _roomUserManager = new(this);
+        _roomUserManager = new(this, _groupManager, _userDataFactory);
         _filterComponent = new(this, _database);
         _wiredComponent = new(this, _database);
         _bansComponent = new(this, _database);
@@ -449,7 +455,7 @@ public class Room : RoomData
         {
             if (user == null)
                 continue;
-            session.Send(new UsersComposer(user));
+            session.Send(new UsersComposer(user, _groupManager, _userDataFactory));
             if (user.IsBot && user.BotData.DanceId > 0)
                 session.Send(new DanceComposer(user, user.BotData.DanceId));
             else if (!user.IsBot && !user.IsPet && user.IsDancing)

--- a/HabboHotel/Rooms/RoomManager.cs
+++ b/HabboHotel/Rooms/RoomManager.cs
@@ -5,6 +5,8 @@ using Plus.Core;
 using Plus.Core.Language;
 using Plus.Database;
 using Plus.HabboHotel.GameClients;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 using Plus.Utilities;
 
 namespace Plus.HabboHotel.Rooms;
@@ -15,6 +17,8 @@ public class RoomManager : IRoomManager
     private readonly IDatabase _database;
     private readonly ILanguageManager _languageManager;
     private readonly IRoomDataLoader _roomDataLoader;
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
 
     private readonly object _roomLoadingSync;
 
@@ -25,12 +29,14 @@ public class RoomManager : IRoomManager
     private DateTime _cycleLastExecution;
 
 
-    public RoomManager(ILogger<RoomManager> logger, IDatabase database, ILanguageManager languageManager, IRoomDataLoader roomDataLoader)
+    public RoomManager(ILogger<RoomManager> logger, IDatabase database, ILanguageManager languageManager, IRoomDataLoader roomDataLoader, IGroupManager groupManager, IUserDataFactory userDataFactory)
     {
         _logger = logger;
         _database = database;
         _languageManager = languageManager;
         _roomDataLoader = roomDataLoader;
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
         _roomModels = new();
         _rooms = new();
         _roomLoadingSync = new();
@@ -177,7 +183,7 @@ public class RoomManager : IRoomManager
                 room = null;
                 return false;
             }
-            var myInstance = new Room(data, _database);
+            var myInstance = new Room(data, _database, _groupManager, _userDataFactory);
             if (_rooms.TryAdd(roomId, myInstance))
             {
                 room = myInstance;

--- a/HabboHotel/Rooms/RoomUserManager.cs
+++ b/HabboHotel/Rooms/RoomUserManager.cs
@@ -11,6 +11,8 @@ using Plus.HabboHotel.Rooms.AI;
 using Plus.HabboHotel.Rooms.Games.Teams;
 using Plus.HabboHotel.Rooms.PathFinding;
 using Plus.HabboHotel.Rooms.Trading;
+using Plus.HabboHotel.Groups;
+using Plus.HabboHotel.Users.UserData;
 using Plus.Utilities;
 
 using Dapper;
@@ -21,6 +23,8 @@ public class RoomUserManager
 {
     private ConcurrentDictionary<int, RoomUser> _bots;
     private ConcurrentDictionary<int, RoomUser> _pets;
+    private readonly IGroupManager _groupManager;
+    private readonly IUserDataFactory _userDataFactory;
 
     private int _primaryPrivateUserId;
     private Room _room;
@@ -30,9 +34,11 @@ public class RoomUserManager
     public int UserCount;
 
 
-    public RoomUserManager(Room room)
+    public RoomUserManager(Room room, IGroupManager groupManager, IUserDataFactory userDataFactory)
     {
         _room = room;
+        _groupManager = groupManager;
+        _userDataFactory = userDataFactory;
         _users = new();
         _pets = new();
         _bots = new();
@@ -75,7 +81,7 @@ public class RoomUserManager
         else
             user.BotAi.Init(bot.BotId, user.VirtualId, _room.RoomId, user, _room);
         user.UpdateNeeded = true;
-        _room.SendPacket(new UsersComposer(user));
+        _room.SendPacket(new UsersComposer(user, _groupManager, _userDataFactory));
         if (user.IsPet)
         {
             if (_pets.ContainsKey(user.PetData.PetId))
@@ -190,7 +196,7 @@ public class RoomUserManager
                 user.SetRot(model.DoorOrientation, false);
             }
         }
-        _room.SendPacket(new UsersComposer(user));
+        _room.SendPacket(new UsersComposer(user, _groupManager, _userDataFactory));
         if (_room.CheckRights(session, true))
         {
             user.SetStatus("flatctrl", "useradmin");


### PR DESCRIPTION
## Summary
- replace static timestamp references with `DateTimeOffset`
- inject dependencies into packet events and composer
- remove static `PlusEnvironment` references in room user logic

## Testing
- `dotnet restore 'Plus Emulator.sln'`
- `dotnet build 'Plus Emulator.csproj' -c Release`
- `dotnet format 'Plus Emulator.csproj' --verify-no-changes` *(fails: ENDOFLINE errors)*

------
https://chatgpt.com/codex/tasks/task_e_688cc1246aa08323b78e31d4bf8e9861